### PR TITLE
Add more test cases to functions

### DIFF
--- a/xpath_test.go
+++ b/xpath_test.go
@@ -193,8 +193,7 @@ func TestFunction(t *testing.T) {
 	testXPath3(t, html, "//title[substring(.,0)='Hello']", selectNode(html, "//title"))
 	testXPath3(t, html, "//title[substring(text(),0,4)='Hell']", selectNode(html, "//title"))
 	testXPath3(t, html, "//title[substring(self::*,0,4)='Hell']", selectNode(html, "//title"))
-	testXPath2(t, html, "//title[substring(child::*,0)]", 0)      // Here substring return boolen (false), should it?
-	testXPath2(t, html, "//title[substring(child::*,0) = '']", 0) // Here substring return boolen (false), should it?
+	testXPath2(t, html, "//title[substring(child::*,0)]", 0) // Here substring return boolen (false), should it?
 	testXPath3(t, html, "//li[not(a)]", selectNode(html, "//ul/li[4]"))
 	testXPath2(t, html, "//li/a[not(@id='1')]", 2) //  //li/a[@id!=1]
 	testXPath2(t, html, "//h1[string-length(normalize-space(' abc ')) = 3]", 1)
@@ -233,6 +232,8 @@ func TestPanic(t *testing.T) {
 	assertPanic(t, func() { testXPath3(t, html, "//title[substring(.,'')=0]", nil) })
 	assertPanic(t, func() { testXPath3(t, html, "//title[substring(.,4,'')=0]", nil) })
 	assertPanic(t, func() { testXPath3(t, html, "//title[substring(.,4,4)=0]", nil) })
+	assertPanic(t, func() { testXPath2(t, html, "//title[substring(child::*,0) = '']", 0) }) // Here substring return boolen (false), should it?
+
 }
 
 func assertPanic(t *testing.T, f func()) {

--- a/xpath_test.go
+++ b/xpath_test.go
@@ -192,10 +192,17 @@ func TestFunction(t *testing.T) {
 	testXPath3(t, html, "//h1[normalize-space(text())='This is a H1']", selectNode(html, "//h1"))
 	testXPath3(t, html, "//title[substring(.,0)='Hello']", selectNode(html, "//title"))
 	testXPath3(t, html, "//title[substring(text(),0,4)='Hell']", selectNode(html, "//title"))
+	testXPath3(t, html, "//title[substring(self::*,0,4)='Hell']", selectNode(html, "//title"))
+	testXPath2(t, html, "//title[substring(child::*,0)]", 0)      // Here substring return boolen (false), should it?
+	testXPath2(t, html, "//title[substring(child::*,0) = '']", 0) // Here substring return boolen (false), should it?
 	testXPath3(t, html, "//li[not(a)]", selectNode(html, "//ul/li[4]"))
 	testXPath2(t, html, "//li/a[not(@id='1')]", 2) //  //li/a[@id!=1]
 	testXPath2(t, html, "//h1[string-length(normalize-space(' abc ')) = 3]", 1)
 	testXPath2(t, html, "//h1[string-length(normalize-space(self::text())) = 12]", 1)
+	testXPath2(t, html, "//title[string-length(normalize-space(child::*)) = 0]", 1)
+	testXPath2(t, html, "//title[string-length(self::text()) = 5]", 1) // Hello = 5
+	testXPath2(t, html, "//title[string-length(child::*) = 5]", 0)
+	testXPath2(t, html, "//title[sum('Hello') = 0]", 1) // Hello = 5. This test pass, but should it?
 	testXPath2(t, html, "//ul[count(li)=4]", 1)
 	if MustCompile("sum(1+2)").Evaluate(createNavigator(html)).(float64) != 3 { // 1+2+3
 		t.Fatal("sum(1+2) != 3")
@@ -210,6 +217,31 @@ func TestFunction(t *testing.T) {
 	if MustCompile(`concat(" ",//a[@id='1']/@href," ")`).Evaluate(createNavigator(html)).(string) != " / " {
 		t.Fatal("concat()")
 	}
+}
+
+func TestPanic(t *testing.T) {
+	// starts-with
+	assertPanic(t, func() { testXPath(t, html, "//*[starts-with(0, 0)]", "") })
+	assertPanic(t, func() { testXPath(t, html, "//*[starts-with(name(), 0)]", "") })
+	//ends-with
+	assertPanic(t, func() { testXPath(t, html, "//*[ends-with(0, 0)]", "") })
+	assertPanic(t, func() { testXPath(t, html, "//*[ends-with(name(), 0)]", "") })
+	// contains
+	assertPanic(t, func() { testXPath2(t, html, "//*[contains(0, 0)]", 0) })
+	assertPanic(t, func() { testXPath2(t, html, "//*[contains(@href, 0)]", 0) })
+	// substring
+	assertPanic(t, func() { testXPath3(t, html, "//title[substring(.,'')=0]", nil) })
+	assertPanic(t, func() { testXPath3(t, html, "//title[substring(.,4,'')=0]", nil) })
+	assertPanic(t, func() { testXPath3(t, html, "//title[substring(.,4,4)=0]", nil) })
+}
+
+func assertPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	f()
 }
 
 func TestEvaluate(t *testing.T) {


### PR DESCRIPTION
I tried to cover almost all function cases.
The coverage is almost 100% now.

But you should take a look at those two tests:

```go
testXPath2(t, html, "//title[sum('Hello') = 0]", 1) // Hello = 5. This test pass, but should it?
testXPath2(t, html, "//title[substring(child::*,0)]", 0) // Here substring return boolen (false), should it?
```