### PR TITLE
Use stdlib round for Go 1.10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 go:
   - 1.6
-  - 1.7
-  - 1.8
+  - 1.9
+  - '1.10'
 
 install:
   - go get github.com/mattn/goveralls

--- a/func.go
+++ b/func.go
@@ -125,16 +125,6 @@ func floorFunc(q query, t iterator) interface{} {
 	return math.Floor(val)
 }
 
-// math.Round() is supported by Go 1.9x,
-// This method just compatible for version <1.9x.
-// https://github.com/golang/go/issues/4594
-func round(f float64) int {
-	if math.Abs(f) < 0.5 {
-		return 0
-	}
-	return int(f + math.Copysign(0.5, f))
-}
-
 // roundFunc is a XPath Node Set functions round(node-set).
 func roundFunc(q query, t iterator) interface{} {
 	val := asNumber(t, q.Evaluate(t))

--- a/func_go110.go
+++ b/func_go110.go
@@ -1,0 +1,9 @@
+// +build go1.10
+
+package xpath
+
+import "math"
+
+func round(f float64) int {
+	return int(math.Round(f))
+}

--- a/func_pre_go110.go
+++ b/func_pre_go110.go
@@ -1,0 +1,15 @@
+// +build !go1.10
+
+package xpath
+
+import "math"
+
+// math.Round() is supported by Go 1.10+,
+// This method just compatible for version <1.10.
+// https://github.com/golang/go/issues/20100
+func round(f float64) int {
+	if math.Abs(f) < 0.5 {
+		return 0
+	}
+	return int(f + math.Copysign(0.5, f))
+}


### PR DESCRIPTION
* Use stdlib round only for Go 1.10 and a custom implementation otherwise
* Test on Go 1.9 and 1.10