### PR TITLE
fix parsing bug #7 (in xmlquery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Supported Features
 
 - `a|b` : All nodes matching a or b, union operation(not boolean or).
 
+- `(a, b, c)` : Evaluates each of its operands and concatenates the resulting sequences, in order, into a single result sequence
+
+
 #### Node Axes 
 
 - `child::*` : The child axis selects children of the current node.


### PR DESCRIPTION
This PR fixes [#7](https://github.com/antchfx/xmlquery/issues/7) (from xmlquery repository).

While working on it I discovered another bug that fails to parse a filter if it is after `self` or `parent` step element. I fixed it without opening another issue because it is part of the xpath example in #7.
