### PR TITLE
performance optimization & bugfix

### DIFF
--- a/func_test.go
+++ b/func_test.go
@@ -1,0 +1,48 @@
+package xpath
+
+import "testing"
+
+type testQuery string
+
+func (t testQuery) Select(_ iterator) NodeNavigator {
+	panic("implement me")
+}
+
+func (t testQuery) Clone() query {
+	return t
+}
+
+func (t testQuery) Evaluate(_ iterator) interface{} {
+	return string(t)
+}
+
+const strForNormalization = "\t    \rloooooooonnnnnnngggggggg  \r \n tes  \u00a0 t strin \n\n \r g "
+const expectedStrAfterNormalization = `loooooooonnnnnnngggggggg tes t strin g`
+
+func Test_NormalizeSpaceFunc(t *testing.T) {
+	result := normalizespaceFunc(testQuery(strForNormalization), nil).(string)
+	if expectedStrAfterNormalization != result {
+		t.Fatalf("unexpected result '%s'", result)
+	}
+}
+
+func Test_ConcatFunc(t *testing.T) {
+	result := concatFunc(testQuery("a"), testQuery("b"))(nil, nil).(string)
+	if "ab" != result {
+		t.Fatalf("unexpected result '%s'", result)
+	}
+}
+
+func Benchmark_NormalizeSpaceFunc(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = normalizespaceFunc(testQuery(strForNormalization), nil)
+	}
+}
+
+func Benchmark_ConcatFunc(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = concatFunc(testQuery("a"), testQuery("b"))(nil, nil)
+	}
+}

--- a/operator.go
+++ b/operator.go
@@ -173,7 +173,7 @@ func cmpNodeSetNodeSet(t iterator, op string, m, n interface{}) bool {
 	if y == nil {
 		return false
 	}
-	return cmpStringStringF(op,x.Value(),y.Value())
+	return cmpStringStringF(op, x.Value(), y.Value())
 }
 
 func cmpStringNumeric(t iterator, op string, m, n interface{}) bool {

--- a/xpath_test.go
+++ b/xpath_test.go
@@ -278,7 +278,7 @@ func TestFunction(t *testing.T) {
 
 func TestTransformFunctionReverse(t *testing.T) {
 	nodes := selectNodes(html, "reverse(//li)")
-	expectedReversedNodeValues := []string { "", "login", "about", "Home" }
+	expectedReversedNodeValues := []string{"", "login", "about", "Home"}
 	if len(nodes) != len(expectedReversedNodeValues) {
 		t.Fatalf("reverse(//li) should return %d <li> nodes", len(expectedReversedNodeValues))
 	}


### PR DESCRIPTION
# Before:
### Benchmark:
```
pkg: github.com/antchfx/xpath
Benchmark_NormalizeSpaceFunc-4    478104	     2441 ns/op	    305 B/op	      9 allocs/op
Benchmark_ConcatFunc-4           3489579	     346 ns/op	    194 B/op	      10 allocs/op
PASS
```

### Test: (unicode space "\u00a0" wasn't processed correctly)
```
=== RUN   Test_NormalizeSpaceFunc
--- FAIL: Test_NormalizeSpaceFunc (0.00s)
    func_test.go:25: unexpected result 'loooooooonnnnnnngggggggg tes   t strin  g'
FAIL
```

# After:
### Benchmark:
```
pkg: github.com/antchfx/xpath
Benchmark_NormalizeSpaceFunc-4   2447773	      453 ns/op	    240 B/op	      4 allocs/op
Benchmark_ConcatFunc-4           4704387	      250 ns/op	    152 B/op	      8 allocs/op
PASS
```

### Test:
```
=== RUN   Test_NormalizeSpaceFunc
--- PASS: Test_NormalizeSpaceFunc (0.00s)
PASS
```