### PR TITLE
avoid nil pointer panic (thread save)

### DIFF
--- a/func.go
+++ b/func.go
@@ -58,6 +58,7 @@ func lastFunc(q query, t iterator) interface{} {
 // countFunc is a XPath Node Set functions count(node-set).
 func countFunc(q query, t iterator) interface{} {
 	var count = 0
+	q = functionArgs(q)
 	test := predicate(q)
 	switch typ := q.Evaluate(t).(type) {
 	case query:
@@ -73,7 +74,7 @@ func countFunc(q query, t iterator) interface{} {
 // sumFunc is a XPath Node Set functions sum(node-set).
 func sumFunc(q query, t iterator) interface{} {
 	var sum float64
-	switch typ := q.Evaluate(t).(type) {
+	switch typ := functionArgs(q).Evaluate(t).(type) {
 	case query:
 		for node := typ.Select(t); node != nil; node = typ.Select(t) {
 			if v, err := strconv.ParseFloat(node.Value(), 64); err == nil {
@@ -116,19 +117,19 @@ func asNumber(t iterator, o interface{}) float64 {
 
 // ceilingFunc is a XPath Node Set functions ceiling(node-set).
 func ceilingFunc(q query, t iterator) interface{} {
-	val := asNumber(t, q.Evaluate(t))
+	val := asNumber(t, functionArgs(q).Evaluate(t))
 	return math.Ceil(val)
 }
 
 // floorFunc is a XPath Node Set functions floor(node-set).
 func floorFunc(q query, t iterator) interface{} {
-	val := asNumber(t, q.Evaluate(t))
+	val := asNumber(t, functionArgs(q).Evaluate(t))
 	return math.Floor(val)
 }
 
 // roundFunc is a XPath Node Set functions round(node-set).
 func roundFunc(q query, t iterator) interface{} {
-	val := asNumber(t, q.Evaluate(t))
+	val := asNumber(t, functionArgs(q).Evaluate(t))
 	//return math.Round(val)
 	return round(val)
 }
@@ -239,19 +240,19 @@ func asString(t iterator, v interface{}) string {
 
 // booleanFunc is a XPath functions boolean([node-set]).
 func booleanFunc(q query, t iterator) interface{} {
-	v := q.Evaluate(t)
+	v := functionArgs(q).Evaluate(t)
 	return asBool(t, v)
 }
 
 // numberFunc is a XPath functions number([node-set]).
 func numberFunc(q query, t iterator) interface{} {
-	v := q.Evaluate(t)
+	v := functionArgs(q).Evaluate(t)
 	return asNumber(t, v)
 }
 
 // stringFunc is a XPath functions string([node-set]).
 func stringFunc(q query, t iterator) interface{} {
-	v := q.Evaluate(t)
+	v := functionArgs(q).Evaluate(t)
 	return asString(t, v)
 }
 
@@ -346,7 +347,7 @@ var (
 // normalizespaceFunc is XPath functions normalize-space(string?)
 func normalizespaceFunc(q query, t iterator) interface{} {
 	var m string
-	switch typ := q.Evaluate(t).(type) {
+	switch typ := functionArgs(q).Evaluate(t).(type) {
 	case string:
 		m = typ
 	case query:
@@ -491,7 +492,7 @@ func replaceFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
 
 // notFunc is XPATH functions not(expression) function operation.
 func notFunc(q query, t iterator) interface{} {
-	switch v := q.Evaluate(t).(type) {
+	switch v := functionArgs(q).Evaluate(t).(type) {
 	case bool:
 		return !v
 	case query:


### PR DESCRIPTION
Issue https://github.com/antchfx/xpath/issues/43 didn't fix problem
I got panic:
```
	runtime error: invalid memory address or nil pointer dereference
	goroutine 19231 [running]:
	******
	panic(0x1c60160, 0x29801c0)
		/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2
	github.com/antchfx/xpath.(*attributeQuery).Select(0xc0019bba20, 0x201ee00, 0xc0087c4a40, 0x2034f40, 0xc0019bba20)
		/Users/d.laptev/Dev/go/pkg/mod/github.com/antchfx/xpath@v1.1.8/query.go:147 +0x2f
	github.com/antchfx/xpath.normalizespaceFunc(0x2034f40, 0xc0019bba20, 0x201ee00, 0xc0087c4a40, 0xc0048fc350, 0xc0048fc350)
		/Users/d.laptev/Dev/go/pkg/mod/github.com/antchfx/xpath@v1.1.8/func.go:354 +0x444

```

Panic didn't happen when i disable cache in htmlquery