### PR TITLE
Improve number handling by returning NaN for non-numbers

### DIFF
--- a/func.go
+++ b/func.go
@@ -122,17 +122,19 @@ func asNumber(t iterator, o interface{}) float64 {
 		return typ
 	case string:
 		v, err := strconv.ParseFloat(typ, 64)
-		if err != nil {
-			panic(errors.New("ceiling() function argument type must be a node-set or number"))
+		if err == nil {
+			return v
 		}
-		return v
 	}
-	return 0
+	return math.NaN()
 }
 
 // ceilingFunc is a XPath Node Set functions ceiling(node-set).
 func ceilingFunc(q query, t iterator) interface{} {
 	val := asNumber(t, functionArgs(q).Evaluate(t))
+	// if math.IsNaN(val) {
+	// 	panic(errors.New("ceiling() function argument type must be a valid number"))
+	// }
 	return math.Ceil(val)
 }
 

--- a/func_go110.go
+++ b/func_go110.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package xpath
@@ -11,6 +12,6 @@ func round(f float64) int {
 	return int(math.Round(f))
 }
 
-func newStringBuilder() stringBuilder{ 
+func newStringBuilder() stringBuilder {
 	return &strings.Builder{}
 }

--- a/func_pre_go110.go
+++ b/func_pre_go110.go
@@ -1,3 +1,4 @@
+//go:build !go1.10
 // +build !go1.10
 
 package xpath


### PR DESCRIPTION
When processing unknown documents, fields that _should_ contain numbers might, for whatever reason, _actually_ contain e.g. a string. In this case the current implementation is also a bit inconsistent and will return a `float64(0)` when performing a `number(//some_string_field)` query and will panic if executed on a string. The latter might happen if the query is constructed prgramatically.

The present PR changes the behavior such that the above query will return `math.NaN()` and leaves the value handling to the caller. If required, the previous behavior can be reconstructed in `ceil`, `floor` etc which will now also return `NaN`s.