### PR TITLE
add CompileWithNS

### DIFF
--- a/build.go
+++ b/build.go
@@ -44,6 +44,12 @@ func axisPredicate(root *axisNode) func(NodeNavigator) bool {
 	predicate := func(n NodeNavigator) bool {
 		if typ == n.NodeType() || typ == allNode {
 			if nametest {
+				type namespaceURL interface {
+					NamespaceURL() string
+				}
+				if ns, ok := n.(namespaceURL); ok && root.hasNamespaceURI {
+					return root.LocalName == n.LocalName() && root.namespaceURI == ns.NamespaceURL()
+				}
 				if root.LocalName == n.LocalName() && root.Prefix == n.Prefix() {
 					return true
 				}
@@ -539,7 +545,7 @@ func (b *builder) processNode(root node) (q query, err error) {
 }
 
 // build builds a specified XPath expressions expr.
-func build(expr string) (q query, err error) {
+func build(expr string, namespaces map[string]string) (q query, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			switch x := e.(type) {
@@ -552,7 +558,7 @@ func build(expr string) (q query, err error) {
 			}
 		}
 	}()
-	root := parse(expr)
+	root := parse(expr, namespaces)
 	b := &builder{}
 	return b.processNode(root)
 }

--- a/parse.go
+++ b/parse.go
@@ -69,8 +69,9 @@ const (
 )
 
 type parser struct {
-	r *scanner
-	d int
+	r          *scanner
+	d          int
+	namespaces map[string]string
 }
 
 // newOperatorNode returns new operator node OperatorNode.
@@ -84,8 +85,8 @@ func newOperandNode(v interface{}) node {
 }
 
 // newAxisNode returns new axis node AxisNode.
-func newAxisNode(axeTyp, localName, prefix, prop string, n node) node {
-	return &axisNode{
+func newAxisNode(axeTyp, localName, prefix, prop string, n node, opts ...func(p *axisNode)) node {
+	a := axisNode{
 		nodeType:  nodeAxis,
 		LocalName: localName,
 		Prefix:    prefix,
@@ -93,6 +94,10 @@ func newAxisNode(axeTyp, localName, prefix, prop string, n node) node {
 		Prop:      prop,
 		Input:     n,
 	}
+	for _, o := range opts {
+		o(&a)
+	}
+	return &a
 }
 
 // newVariableNode returns new variable node VariableNode.
@@ -469,7 +474,16 @@ func (p *parser) parseNodeTest(n node, axeTyp string) (opnd node) {
 			if p.r.name == "*" {
 				name = ""
 			}
-			opnd = newAxisNode(axeTyp, name, prefix, "", n)
+			opnd = newAxisNode(axeTyp, name, prefix, "", n, func(a *axisNode) {
+				if prefix != "" && p.namespaces != nil {
+					if ns, ok := p.namespaces[prefix]; ok {
+						a.hasNamespaceURI = true
+						a.namespaceURI = ns
+					} else {
+						panic(fmt.Sprintf("prefix %s not defined.", prefix))
+					}
+				}
+			})
 		}
 	case itemStar:
 		opnd = newAxisNode(axeTyp, "", "", "", n)
@@ -531,11 +545,11 @@ func (p *parser) parseMethod(n node) node {
 }
 
 // Parse parsing the XPath express string expr and returns a tree node.
-func parse(expr string) node {
+func parse(expr string, namespaces map[string]string) node {
 	r := &scanner{text: expr}
 	r.nextChar()
 	r.nextItem()
-	p := &parser{r: r}
+	p := &parser{r: r, namespaces: namespaces}
 	return p.parseExpression(nil)
 }
 
@@ -563,11 +577,13 @@ func (o *operatorNode) String() string {
 // axisNode holds a location step.
 type axisNode struct {
 	nodeType
-	Input     node
-	Prop      string // node-test name.[comment|text|processing-instruction|node]
-	AxeType   string // name of the axes.[attribute|ancestor|child|....]
-	LocalName string // local part name of node.
-	Prefix    string // prefix name of node.
+	Input           node
+	Prop            string // node-test name.[comment|text|processing-instruction|node]
+	AxeType         string // name of the axes.[attribute|ancestor|child|....]
+	LocalName       string // local part name of node.
+	Prefix          string // prefix name of node.
+	namespaceURI    string // namespace URI of node
+	hasNamespaceURI bool   // if namespace URI is set (can be "")
 }
 
 func (a *axisNode) String() string {

--- a/xpath.go
+++ b/xpath.go
@@ -141,7 +141,7 @@ func Compile(expr string) (*Expr, error) {
 	if expr == "" {
 		return nil, errors.New("expr expression is nil")
 	}
-	qy, err := build(expr)
+	qy, err := build(expr, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -158,4 +158,19 @@ func MustCompile(expr string) *Expr {
 		return &Expr{s: expr, q: nopQuery{}}
 	}
 	return exp
+}
+
+// CompileWithNS compiles an XPath expression string, using given namespaces map.
+func CompileWithNS(expr string, namespaces map[string]string) (*Expr, error) {
+	if expr == "" {
+		return nil, errors.New("expr expression is nil")
+	}
+	qy, err := build(expr, namespaces)
+	if err != nil {
+		return nil, err
+	}
+	if qy == nil {
+		return nil, fmt.Errorf(fmt.Sprintf("undeclared variable in XPath expression: %s", expr))
+	}
+	return &Expr{s: expr, q: qy}, nil
 }


### PR DESCRIPTION
Related to discussion in https://github.com/antchfx/xmlquery/issues/15

This pull-request proposes a function;
```go
func CompileWithNS(expr string, namespaces map[string]string) (*Expr, error)
```
as an alternative to 
```go
func Compile(expr string) (*Expr, error)
```

This allows for more readable xpath expressions without relying on prefix values. For example:

```xml
<tags>
    <a:tag xmlns:a="example.com/tag" />
    <b:tag xmlns:b="example.com/tag" />
</tags>
```

Using `Compile("//a:tag")` is not desirable because `a:` is not guaranteed to not change, and does not match `b:`. [Namespaces in XML]( https://www.w3.org/TR/xml-names/#ns-qualnames) says:

> Note that the prefix functions _only_ as a placeholder for a namespace name. Applications _SHOULD_ use the namespace name, not the prefix, in constructing names whose scope extends beyond the containing document.

A current workaround is `Compile("//*[local-name()='tag' and namespace-uri()='example.com/tag']")` which quickly gets messy.

I propose `CompileWithNS("//e:tag", map[string]string{"e": "example.com/tag"})` which scales better since namespace bindings can be reused.