### PR TITLE
fix: converting an empty node set to a number should return NaN

### DIFF
--- a/func.go
+++ b/func.go
@@ -113,7 +113,7 @@ func asNumber(t iterator, o interface{}) float64 {
 	case query:
 		node := typ.Select(t)
 		if node == nil {
-			return float64(0)
+			return math.NaN()
 		}
 		if v, err := strconv.ParseFloat(node.Value(), 64); err == nil {
 			return v

--- a/xpath_function_test.go
+++ b/xpath_function_test.go
@@ -175,6 +175,8 @@ func Test_func_number(t *testing.T) {
 	test_xpath_eval(t, empty_example, `number("10") > 10`, false)
 	test_xpath_eval(t, empty_example, `number("10") = 10`, true)
 	test_xpath_eval(t, empty_example, `number("123") < 1000`, true)
+	test_xpath_eval(t, empty_example, `number(//non-existent-node) = 0`, false)
+	assertTrue(t, math.IsNaN(MustCompile(`number(//non-existent-node)`).Evaluate(createNavigator(empty_example)).(float64)))
 	assertTrue(t, math.IsNaN(MustCompile(`number("123a")`).Evaluate(createNavigator(empty_example)).(float64)))
 }
 


### PR DESCRIPTION
Makes `number(//non-existent-node)` return `NaN` instead of `0`, fixes issue #96.