### PR TITLE
feat: add support for regexp in xpath replace function

### DIFF
--- a/func.go
+++ b/func.go
@@ -564,8 +564,17 @@ func replaceFunc(arg1, arg2, arg3 query) func(query, iterator) interface{} {
 		str := asString(t, functionArgs(arg1).Evaluate(t))
 		src := asString(t, functionArgs(arg2).Evaluate(t))
 		dst := asString(t, functionArgs(arg3).Evaluate(t))
+		e, err := getRegexp(src)
+		if err != nil {
+			panic(fmt.Errorf("replace() function second argument is not a valid regexp pattern, err: %s", err.Error()))
+		}
 
-		return strings.Replace(str, src, dst, -1)
+		// replace all $i to ${i} for golang regexp.Expand
+		for idx := e.NumSubexp(); idx > 0; idx-- {
+			dst = strings.ReplaceAll(dst, fmt.Sprintf("$%d", idx), fmt.Sprintf("${%d}", idx))
+		}
+
+		return e.ReplaceAllString(str, dst)
 	}
 }
 

--- a/xpath_function_test.go
+++ b/xpath_function_test.go
@@ -195,13 +195,16 @@ func Test_func_replace(t *testing.T) {
 	test_xpath_eval(t, empty_example, `replace("abracadabra", "a", "")`, "brcdbr")
 	// The below xpath expressions is not supported yet
 	//
-	//test_xpath_eval(t, empty_example, `replace("abracadabra", "a.*a", "*")`, "*")
-	//test_xpath_eval(t, empty_example, `replace("abracadabra", "a.*?a", "*")`, "*c*bra")
-	//test_xpath_eval(t, empty_example, `replace("abracadabra", ".*?", "$1")`, "*c*bra") // error, because the pattern matches the zero-length string
-	//test_xpath_eval(t, empty_example, `replace("AAAA", "A+", "b")`, "b")
-	//test_xpath_eval(t, empty_example, `replace("AAAA", "A+?", "b")`, "bbb")
-	//test_xpath_eval(t, empty_example, `replace("darted", "^(.*?)d(.*)$", "$1c$2")`, "carted")
-	//test_xpath_eval(t, empty_example, `replace("abracadabra", "a(.)", "a$1$1")`, "abbraccaddabbra")
+	test_xpath_eval(t, empty_example, `replace("abracadabra", "a.*a", "*")`, "*")
+	test_xpath_eval(t, empty_example, `replace("abracadabra", "a.*?a", "*")`, "*c*bra")
+	// test_xpath_eval(t, empty_example, `replace("abracadabra", ".*?", "$1")`, "*c*bra") // error, because the pattern matches the zero-length string
+	test_xpath_eval(t, empty_example, `replace("AAAA", "A+", "b")`, "b")
+	test_xpath_eval(t, empty_example, `replace("AAAA", "A+?", "b")`, "bbbb")
+	test_xpath_eval(t, empty_example, `replace("darted", "^(.*?)d(.*)$", "$1c$2")`, "carted")
+	test_xpath_eval(t, empty_example, `replace("abracadabra", "a(.)", "a$1$1")`, "abbraccaddabbra")
+	test_xpath_eval(t, empty_example, `replace("abcd", "(ab)|(a)", "[1=$1][2=$2]")`, "[1=ab][2=]cd")
+	test_xpath_eval(t, empty_example, `replace("1/1/c11/1", "(.*)/[^/]+$", "$1")`, "1/1/c11")
+	test_xpath_eval(t, empty_example, `replace("A/B/C/D/E/F/G/H/I/J/K/L", "([^/]*)/([^/]*)/([^/]*)/([^/]*)/([^/]*)/([^/]*)/([^/]*)/([^/]*)/([^/]*)/(.*)", "$1-$2-$3-$4-$5-$6-$7-$8-$9-$10")`, "A-B-C-D-E-F-G-H-I-J/K/L")
 }
 
 func Test_func_reverse(t *testing.T) {


### PR DESCRIPTION
Noticed in our usecase that replace function didn't work with regexp patterns. Error conditions are still missing from replace