### PR TITLE
improve getHashCode by removing fmt.Sprintf

### DIFF
--- a/query.go
+++ b/query.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"reflect"
+	"strconv"
 )
 
 // The return type of the XPath expression.
@@ -1364,19 +1365,23 @@ func getHashCode(n NodeNavigator) uint64 {
 	var sb bytes.Buffer
 	switch n.NodeType() {
 	case AttributeNode, TextNode, CommentNode:
-		sb.WriteString(fmt.Sprintf("%s=%s", n.LocalName(), n.Value()))
+		sb.WriteString(n.LocalName())
+		sb.WriteByte('=')
+		sb.WriteString(n.Value())
 		// https://github.com/antchfx/htmlquery/issues/25
 		d := 1
 		for n.MoveToPrevious() {
 			d++
 		}
-		sb.WriteString(fmt.Sprintf("-%d", d))
+		sb.WriteByte('-')
+		sb.WriteString(strconv.Itoa(d))
 		for n.MoveToParent() {
 			d = 1
 			for n.MoveToPrevious() {
 				d++
 			}
-			sb.WriteString(fmt.Sprintf("-%d", d))
+			sb.WriteByte('-')
+			sb.WriteString(strconv.Itoa(d))
 		}
 	case ElementNode:
 		sb.WriteString(n.Prefix() + n.LocalName())
@@ -1384,14 +1389,16 @@ func getHashCode(n NodeNavigator) uint64 {
 		for n.MoveToPrevious() {
 			d++
 		}
-		sb.WriteString(fmt.Sprintf("-%d", d))
+		sb.WriteByte('-')
+		sb.WriteString(strconv.Itoa(d))
 
 		for n.MoveToParent() {
 			d = 1
 			for n.MoveToPrevious() {
 				d++
 			}
-			sb.WriteString(fmt.Sprintf("-%d", d))
+			sb.WriteByte('-')
+			sb.WriteString(strconv.Itoa(d))
 		}
 	}
 	h := fnv.New64a()

--- a/xpath_function_test.go
+++ b/xpath_function_test.go
@@ -262,3 +262,36 @@ func Benchmark_ConcatFunc(b *testing.B) {
 		_ = concatFunc(testQuery("a"), testQuery("b"))(nil, nil)
 	}
 }
+
+func Benchmark_GetHashCode(b *testing.B) {
+	// Create a more complex test node that will actually go through the full getHashCode paths
+	doc := createNavigator(book_example)
+	doc.MoveToRoot()
+	doc.MoveToChild() // Move to the first element
+	doc.MoveToChild() // Deeper
+	// Find a node with attributes
+	var node NodeNavigator
+	for {
+		if doc.NodeType() == AttributeNode || doc.NodeType() == TextNode || doc.NodeType() == CommentNode {
+			node = doc.Copy()
+			break
+		}
+		if !doc.MoveToNext() {
+			if !doc.MoveToChild() {
+				// If we can't find a suitable node, default to using the first element
+				doc.MoveToRoot()
+				doc.MoveToChild()
+				node = doc.Copy()
+				break
+			}
+		}
+	}
+
+	b.Run("getHashCode", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			n := node.Copy()
+			_ = getHashCode(n)
+		}
+	})
+}


### PR DESCRIPTION
I'm using this library do perform quite a bit of ancestor query but is hitting high cpu usage.
did profiling and found out that getHashCode is rather expensive.

<img width="1915" alt="image" src="https://github.com/user-attachments/assets/b9badd67-6f1a-4d1e-9e65-5c5a6ceb6a57" />

did some further research and found out that sprintf can be expensive as shown in the profiling results
https://medium.com/swlh/bad-go-frivolous-sprintf-2ad28fedf1a0
https://hackernoon.com/fmtsprintf-looks-simple-but-will-burn-a-hole-in-your-pocket

# Before

##  Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/antchfx/xpath
cpu: Apple M3 Pro
=== RUN   Benchmark_GetHashCode
Benchmark_GetHashCode
=== RUN   Benchmark_GetHashCode/getHashCode
Benchmark_GetHashCode/getHashCode
Benchmark_GetHashCode/getHashCode-12             2976260               402.4 ns/op           144 B/op         10 allocs/op
PASS
ok      github.com/antchfx/xpath        2.555s
```

# After

##  Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/antchfx/xpath
cpu: Apple M3 Pro
=== RUN   Benchmark_GetHashCode
Benchmark_GetHashCode
=== RUN   Benchmark_GetHashCode/getHashCode
Benchmark_GetHashCode/getHashCode
Benchmark_GetHashCode/getHashCode-12             9322789               122.1 ns/op            88 B/op          2 allocs/op
PASS
ok      github.com/antchfx/xpath        2.000s
```