### PR TITLE
Fix positional predicate for the "ancestor" axis

### DIFF
--- a/xpath_axes_test.go
+++ b/xpath_axes_test.go
@@ -32,6 +32,39 @@ func Test_ancestor(t *testing.T) {
 	//test_xpath_elements(t, employee_example, `//ancestor::name`, 4, 9, 14)
 }
 
+func Test_ancestor_predicate(t *testing.T) {
+	doc := createElement(0, "",
+		createElement(1, "html",
+			createElement(2, "body",
+				createElement(3, "h1"),
+				createElement(4, "section",
+					createElement(5, "div",
+						createElement(6, "section",
+							createElement(7, "div",
+								createElement(8, "span"),
+							),
+						),
+					),
+				),
+				createElement(9, "section",
+					createElement(10, "div",
+						createElement(11, "section",
+							createElement(12, "div",
+								createElement(13, "span"),
+							),
+						),
+					),
+				),
+			),
+		),
+	)
+
+	test_xpath_elements(t, doc, `//span/ancestor::*`, 7, 6, 5, 4, 2, 1, 12, 11, 10, 9)
+	test_xpath_elements(t, doc, `//span/ancestor::section`, 6, 4, 11, 9)
+	test_xpath_elements(t, doc, `//span/ancestor::section[1]`, 6, 11)
+	test_xpath_elements(t, doc, `//span/ancestor::section[2]`, 4, 9)
+}
+
 func Test_ancestor_or_self(t *testing.T) {
 	// Expected the value is [2, 3, 8, 13], but got [3, 2, 8, 13]
 	test_xpath_elements(t, employee_example, `//employee/ancestor-or-self::*`, 3, 2, 8, 13)

--- a/xpath_test.go
+++ b/xpath_test.go
@@ -587,6 +587,26 @@ func (n *TNode) getAttribute(key string) string {
 	return ""
 }
 
+func createElement(line int, name string, children ...*TNode) *TNode {
+	nodeType := ElementNode
+	if name == "" {
+		nodeType = RootNode
+	}
+	n := createNode(name, nodeType)
+	n.lines = line
+	for _, c := range children {
+		c.Parent = n
+		c.PrevSibling = n.LastChild
+		if c.PrevSibling == nil {
+			n.FirstChild = c
+		} else {
+			c.PrevSibling.NextSibling = c
+		}
+		n.LastChild = c
+	}
+	return n
+}
+
 func createBookExample() *TNode {
 	/*
 	   <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
The expression `/ancestor::div[1]` should select only the first "div" node while traversing up the document tree, but this wasn't the case.

The bug was discovered by [bannmann](https://codeberg.org/bannmann) and [reported to the Readeck project](https://codeberg.org/readeck/readeck/issues/791). Readeck uses XPath expressions to selectively strip parts of HTML documents, but this bug causes significantly larger portions of some documents be wiped due to the overzealous ancestor matching.

This fixes positional predicates by having ancestorQuery implement the Position interface.

The test was written by hand by me and the implementation (plus code comments) was helped by GitHub Copilot w/ GPT-5.

I made a new test helper `createElement` to simplify making nested documents for testing, since the pre-existing trees used in other tests are not suitable for verifying this bug due to not having deep nesting with repeated element names.