### PR TITLE
Fix last() predicate on grouped expressions

### DIFF
--- a/build.go
+++ b/build.go
@@ -208,6 +208,8 @@ func (b *builder) processFilter(root *filterNode, flags flag, props *builderProp
 				switch qyFunc.Input.(type) {
 				case *filterQuery:
 					cond = &lastFuncQuery{Input: qyFunc.Input}
+				case *groupQuery:
+					cond = &lastFuncQuery{Input: qyFunc.Input.Clone()}
 				}
 			}
 		}
@@ -689,9 +691,7 @@ func (b *builder) processNode(root node, flags flag, props *builderProp) (q quer
 			return
 		}
 		q = &groupQuery{Input: q}
-		if b.firstInput == nil {
-			b.firstInput = q
-		}
+		b.firstInput = q
 	}
 	b.parseDepth--
 	return

--- a/xpath_predicate_test.go
+++ b/xpath_predicate_test.go
@@ -27,7 +27,11 @@ func TestPositions(t *testing.T) {
 	test_xpath_elements(t, employee_example, `//employee[last()]`, 13)
 	test_xpath_elements(t, employee_example, `//employee[position() = last()]`, 13)
 	test_xpath_elements(t, book_example, `//book[@category = "web"][2]`, 25)
+	test_xpath_elements(t, book_example, `//book[@category = "web"][last()]`, 25)
 	test_xpath_elements(t, book_example, `(//book[@category = "web"])[2]`, 25)
+	test_xpath_elements(t, book_example, `(//book[@category = "web"])[last()]`, 25)
+	test_xpath_elements(t, employee_example, `(//employee)[last()]`, 13)
+	test_xpath_elements(t, book_example, `(//author)[last()]`, 27)
 }
 
 func TestPredicates(t *testing.T) {


### PR DESCRIPTION
When evaluating expressions like `(//author)[last()]`, the `last()` function was counting sibling nodes per-parent instead of counting the total nodes in the grouped result set. This caused incorrect matches when group members came from different parent nodes.

Reported in https://codeberg.org/readeck/readeck/issues/1104#issuecomment-10562184

Unit tests and fix authored by Claude Code.