### PR TITLE
query: reset mergeQuery iterator in Evaluate

### DIFF
--- a/query.go
+++ b/query.go
@@ -1353,6 +1353,7 @@ func (m *mergeQuery) Select(t iterator) NodeNavigator {
 
 func (m *mergeQuery) Evaluate(t iterator) interface{} {
 	m.Input.Evaluate(t)
+	m.iterator = nil
 	return m
 }
 

--- a/xpath_test.go
+++ b/xpath_test.go
@@ -999,3 +999,19 @@ func createMyBookExample() *TNode {
 	}
 	return doc
 }
+
+func TestMergeQueryStaleStateAcrossEvaluations(t *testing.T) {
+	// A "//name" step compiles to a *mergeQuery; re-evaluating one compiled
+	// expression against a second document must not reuse the first document's
+	// node list.
+	doc := createNode("", RootNode)
+	foo := doc.createChildNode("foo", ElementNode)
+	foo.createChildNode("bar", ElementNode)
+	foo.createChildNode("bar", ElementNode)
+	empty := createNode("", RootNode)
+
+	expr := MustCompile("//bar[true()] and count(//foo)=0")
+	assertFalse(t, expr.Evaluate(createNavigator(empty)).(bool))
+	assertFalse(t, expr.Evaluate(createNavigator(doc)).(bool))
+	assertFalse(t, expr.Evaluate(createNavigator(empty)).(bool))
+}


### PR DESCRIPTION
`//name` steps compile to a `mergeQuery`, and its `Select` only rebuilds the result list when `m.iterator == nil`. Every other node-set query (childQuery, descendantQuery, ancestorQuery, and so on) clears that field in `Evaluate`, but `mergeQuery.Evaluate` didn't, so re-evaluating a compiled expression against a different document reused the node list from the previous one.

This adds the missing `m.iterator = nil` so mergeQuery matches the other queries. Regression test evaluates `//bar[true()] and count(//foo)=0` against two documents and back, which returned true on the third pass before the fix.

Fixes #122