### PR TITLE
Format numbers per the XPath 1.0 string() rules

### DIFF
--- a/func.go
+++ b/func.go
@@ -245,6 +245,23 @@ func asBool(t iterator, v interface{}) bool {
 	}
 }
 
+// formatNumber converts a number to a string per the XPath 1.0 spec (REC 4.2):
+// no exponent for finite values, "Infinity"/"-Infinity", "NaN", and "0" for -0.
+func formatNumber(f float64) string {
+	switch {
+	case math.IsNaN(f):
+		return "NaN"
+	case math.IsInf(f, 1):
+		return "Infinity"
+	case math.IsInf(f, -1):
+		return "-Infinity"
+	case f == 0:
+		return "0"
+	default:
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+}
+
 func asString(t iterator, v interface{}) string {
 	switch v := v.(type) {
 	case nil:
@@ -255,7 +272,7 @@ func asString(t iterator, v interface{}) string {
 		}
 		return "false"
 	case float64:
-		return strconv.FormatFloat(v, 'g', -1, 64)
+		return formatNumber(v)
 	case string:
 		return v
 	case query:
@@ -621,16 +638,7 @@ func concatFunc(args ...query) func(query, iterator) interface{} {
 		b := builderPool.Get().(stringBuilder)
 		for _, v := range args {
 			v = functionArgs(v)
-
-			switch v := v.Evaluate(t).(type) {
-			case string:
-				b.WriteString(v)
-			case query:
-				node := v.Select(t)
-				if node != nil {
-					b.WriteString(node.Value())
-				}
-			}
+			b.WriteString(asString(t, v.Evaluate(t)))
 		}
 		result := b.String()
 		b.Reset()

--- a/xpath_function_test.go
+++ b/xpath_function_test.go
@@ -45,6 +45,13 @@ func Test_func_concat(t *testing.T) {
 	test_xpath_eval(t, book_example, `concat(//book[1]/title, ", ", //book[1]/year)`, "Everyday Italian, 2005")
 	result := concatFunc(testQuery("a"), testQuery("b"))(nil, nil).(string)
 	assertEqual(t, result, "ab")
+	// concat converts each argument with string() (REC 4.2); number and boolean
+	// arguments must be stringified, not silently dropped.
+	test_xpath_eval(t, empty_example, `concat("id-", 5, "-x")`, "id-5-x")
+	test_xpath_eval(t, empty_example, `concat(1, 2, 3)`, "123")
+	test_xpath_eval(t, empty_example, `concat("n=", 1 div 4)`, "n=0.25")
+	test_xpath_eval(t, empty_example, `concat("a", true(), "b")`, "atrueb")
+	test_xpath_eval(t, empty_example, `concat("a", 1 div 0, "z")`, "aInfinityz")
 }
 
 func Test_func_contains(t *testing.T) {
@@ -99,6 +106,23 @@ func Test_func_string(t *testing.T) {
 	test_xpath_eval(t, empty_example, `string(1.23)`, "1.23")
 	test_xpath_eval(t, empty_example, `string(3)`, "3")
 	test_xpath_eval(t, book_example, `string(//book/@category)`, "cooking")
+	// number->string per XPath 1.0 REC 4.2: decimal form, never an exponent.
+	test_xpath_eval(t, empty_example, `string(1000000)`, "1000000")
+	test_xpath_eval(t, empty_example, `string(1234567)`, "1234567")
+	test_xpath_eval(t, empty_example, `string(123456789)`, "123456789")
+	test_xpath_eval(t, empty_example, `string(0.00001)`, "0.00001")
+	test_xpath_eval(t, empty_example, `string(10000000000)`, "10000000000")
+	test_xpath_eval(t, empty_example, `string(100000000000000000000)`, "100000000000000000000")
+	// infinity, NaN and negative zero.
+	test_xpath_eval(t, empty_example, `string(1 div 0)`, "Infinity")
+	test_xpath_eval(t, empty_example, `string(-1 div 0)`, "-Infinity")
+	test_xpath_eval(t, empty_example, `string(0 div 0)`, "NaN")
+	test_xpath_eval(t, empty_example, `string(-0)`, "0")
+	test_xpath_eval(t, empty_example, `string(0 div -1)`, "0")
+	// unchanged finite cases (regression guard).
+	test_xpath_eval(t, empty_example, `string(0.5)`, "0.5")
+	test_xpath_eval(t, empty_example, `string(-3)`, "-3")
+	test_xpath_eval(t, empty_example, `string(0.25)`, "0.25")
 }
 func Test_func_string_empty(t *testing.T) {
 	// https://github.com/antchfx/xpath/issues/113


### PR DESCRIPTION
`string()` on a number — and every other place a number is coerced to text — goes through `asString`, which uses `strconv.FormatFloat(v, 'g', -1, 64)`. Go's `'g'` verb switches to scientific notation whenever that is shorter and prints Go's own `+Inf`/`-Inf`/`-0` tokens, none of which are valid XPath. The [XPath 1.0 REC §4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-string) defines an exact algorithm: finite numbers render in decimal form with no exponent, the infinities become `Infinity`/`-Infinity`, NaN becomes `NaN`, and negative zero becomes `0`.

`concat` has the same root cause from the other side — its type switch only handled `string` and node-set arguments, so a numeric or boolean argument was silently dropped.

Before:

```
string(1000000)          => "1e+06"    want "1000000"
string(0.00001)          => "1e-05"    want "0.00001"
string(1 div 0)          => "+Inf"     want "Infinity"
string(-0)               => "-0"       want "0"
concat("id-", 5, "-x")   => "id--x"    want "id-5-x"
concat(1, 2, 3)          => ""         want "123"
concat("a", true(), "b") => "ab"       want "atrueb"
```

Fix: add `formatNumber` implementing the §4.2 rule and use it in `asString`; route each `concat` argument through `asString` so all argument types are stringified exactly as `string()` converts them.

I checked the output against libxml2 (via lxml) across the common range of magnitudes and they now agree. Two notes on scope:

- For very large / very small magnitudes libxml2 itself switches to scientific notation (e.g. `string(1e20)` -> `1e+20`), which §4.2 does not permit. This change follows §4.2 and always emits decimal form (`100000000000000000000`), so the spec arbitrates that range rather than libxml2.
- It deliberately does not change the number of significant digits (`string(2 div 3)` stays `0.6666666666666666`). `FormatFloat(_, 'f', -1, 64)` already emits the shortest round-tripping representation, which is what §4.2 asks for ("as many digits as are needed to uniquely distinguish the number").

Regression cases added to `Test_func_string` and `Test_func_concat`; the full suite passes. The xmllint property tests in #114 are a complementary differential check, but their generators use integer-only literals and string/path arguments, so these particular edges aren't currently exercised.
