### PR TITLE
Fix remaining XPath comparison coercion edge cases

### DIFF
--- a/func.go
+++ b/func.go
@@ -123,16 +123,16 @@ func asNumber(t iterator, o interface{}) float64 {
 		if node == nil {
 			return math.NaN()
 		}
-		if v, err := strconv.ParseFloat(node.Value(), 64); err == nil {
-			return v
-		}
+		return stringToNumber(node.Value())
 	case float64:
 		return typ
 	case string:
-		v, err := strconv.ParseFloat(typ, 64)
-		if err == nil {
-			return v
+		return stringToNumber(typ)
+	case bool:
+		if typ {
+			return 1
 		}
+		return 0
 	}
 	return math.NaN()
 }

--- a/operator.go
+++ b/operator.go
@@ -1,7 +1,5 @@
 package xpath
 
-import "math"
-
 // The XPath number operator function list.
 
 type logical func(iterator, string, interface{}, interface{}) bool
@@ -15,9 +13,6 @@ var logicalFuncs = [][]logical{
 
 // number vs number
 func cmpNumberNumberF(op string, a, b float64) bool {
-	if math.IsNaN(a) || math.IsNaN(b) {
-		return false
-	}
 	switch op {
 	case "=":
 		return a == b
@@ -109,7 +104,7 @@ func cmpNodeSetString(t iterator, op string, m, n interface{}) bool {
 		if node == nil {
 			break
 		}
-		if cmpStringStringF(op, b, node.Value()) {
+		if cmpStringStringF(op, node.Value(), b) {
 			return true
 		}
 	}

--- a/operator_test.go
+++ b/operator_test.go
@@ -1,0 +1,81 @@
+package xpath
+
+import "testing"
+
+func createComparisonDoc() *TNode {
+	doc := createNode("", RootNode)
+	root := doc.createChildNode("Root", ElementNode)
+	nodes := []struct {
+		name  string
+		value string
+	}{
+		{name: "Low", value: "2"},
+		{name: "High", value: "10"},
+		{name: "Padded", value: " 14 "},
+		{name: "Invalid", value: "abc"},
+	}
+	for _, node := range nodes {
+		child := root.createChildNode(node.name, ElementNode)
+		child.createChildNode(node.value, TextNode)
+	}
+	return doc
+}
+
+func TestXPathComparisons(t *testing.T) {
+	doc := createComparisonDoc()
+	tests := []struct {
+		name string
+		expr string
+		want bool
+	}{
+		{name: "string number greater", expr: `'14' > 0`, want: true},
+		{name: "number string less", expr: `0 < '14'`, want: true},
+		{name: "string number less false", expr: `'14' < 0`, want: false},
+		{name: "number string greater false", expr: `0 > '14'`, want: false},
+		{name: "string number equal", expr: `'14' = 14`, want: true},
+		{name: "number string equal", expr: `14 = '14'`, want: true},
+		{name: "string number not equal", expr: `'14' != 15`, want: true},
+		{name: "number string not equal", expr: `15 != '14'`, want: true},
+
+		{name: "invalid string equals number", expr: `'abc' = 1`, want: false},
+		{name: "number equals invalid string", expr: `1 = 'abc'`, want: false},
+		{name: "invalid string differs from number", expr: `'abc' != 1`, want: true},
+		{name: "number differs from invalid string", expr: `1 != 'abc'`, want: true},
+		{name: "invalid string relational", expr: `'abc' < 1`, want: false},
+		{name: "number invalid string relational", expr: `1 < 'abc'`, want: false},
+		{name: "number trims string whitespace", expr: `number(' 14 ') = 14`, want: true},
+		{name: "number invalid string is NaN", expr: `number('abc') != 1`, want: true},
+		{name: "number converts true", expr: `number(true()) = 1`, want: true},
+		{name: "number converts false", expr: `number(false()) = 0`, want: true},
+
+		{name: "string relational less", expr: `'2' < '10'`, want: true},
+		{name: "string relational greater", expr: `'10' > '2'`, want: true},
+		{name: "string relational less or equal", expr: `'2' <= '10'`, want: true},
+		{name: "string relational greater or equal", expr: `'10' >= '2'`, want: true},
+		{name: "string equality stays lexical", expr: `'2' = '02'`, want: false},
+		{name: "string inequality stays lexical", expr: `'2' != '02'`, want: true},
+
+		{name: "padded node equals number", expr: `//Padded = 14`, want: true},
+		{name: "number equals padded node", expr: `14 = //Padded`, want: true},
+		{name: "invalid node equals number", expr: `//Invalid = 1`, want: false},
+		{name: "number equals invalid node", expr: `1 = //Invalid`, want: false},
+		{name: "invalid node differs from number", expr: `//Invalid != 1`, want: true},
+		{name: "number differs from invalid node", expr: `1 != //Invalid`, want: true},
+
+		{name: "node set less than string", expr: `//Low < '10'`, want: true},
+		{name: "string greater than node set", expr: `'10' > //Low`, want: true},
+		{name: "node set greater than string", expr: `//High > '2'`, want: true},
+		{name: "string less than node set", expr: `'2' < //High`, want: true},
+		{name: "node set less or equal string", expr: `//Low <= '2'`, want: true},
+		{name: "string greater or equal node set", expr: `'10' >= //High`, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MustCompile(tt.expr).Evaluate(createNavigator(doc))
+			if got != tt.want {
+				t.Fatalf("%s: got %v, want %v", tt.expr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #126

The direct `master` fix in 43837f1 covers the original four examples. This follow-up completes the XPath 1.0 comparison behavior around those paths and adds regression coverage.

## What changed

- preserve operand order for node-set/string relational comparisons
- rely on IEEE float comparison semantics so NaN makes `=`/relationals false and `!=` true
- route `asNumber` string and node-set conversion through the shared whitespace-aware helper
- support the XPath `number()` conversion for booleans
- add table-driven tests covering both operand orders, all comparison operators, numeric strings, padded values, non-numeric values, node sets, and scalar strings/numbers

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`