### PR TITLE
fix: round() and mod follow the XPath 1.0 numeric spec

### DIFF
--- a/func.go
+++ b/func.go
@@ -156,11 +156,26 @@ func floorFunc(arg query) func(query, iterator) interface{} {
 	}
 }
 
+// round implements XPath 1.0 round() (REC §4.4): halves round toward +Infinity
+// and NaN/±Infinity pass through, so the result stays a number.
+func round(f float64) float64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return f
+	}
+	if f >= -0.5 && f < 0.5 {
+		return f * 0 // keep the sign of zero per §4.4
+	}
+	r := math.Floor(f)
+	if f-r >= 0.5 {
+		r++
+	}
+	return r
+}
+
 // roundFunc is a XPath Node Set functions round(node-set).
 func roundFunc(arg query) func(query, iterator) interface{} {
 	return func(_ query, t iterator) interface{} {
 		val := asNumber(t, functionArgs(arg).Evaluate(t))
-		//return math.Round(val)
 		return round(val)
 	}
 }

--- a/func_go110.go
+++ b/func_go110.go
@@ -2,14 +2,7 @@
 
 package xpath
 
-import (
-	"math"
-	"strings"
-)
-
-func round(f float64) int {
-	return int(math.Round(f))
-}
+import "strings"
 
 func newStringBuilder() stringBuilder {
 	return &strings.Builder{}

--- a/func_pre_go110.go
+++ b/func_pre_go110.go
@@ -2,20 +2,7 @@
 
 package xpath
 
-import (
-	"bytes"
-	"math"
-)
-
-// math.Round() is supported by Go 1.10+,
-// This method just compatible for version <1.10.
-// https://github.com/golang/go/issues/20100
-func round(f float64) int {
-	if math.Abs(f) < 0.5 {
-		return 0
-	}
-	return int(f + math.Copysign(0.5, f))
-}
+import "bytes"
 
 func newStringBuilder() stringBuilder {
 	return &bytes.Buffer{}

--- a/operator.go
+++ b/operator.go
@@ -262,6 +262,7 @@ var divFunc = func(t iterator, m, n interface{}) interface{} {
 // modFunc is an 'MOD' operator.
 var modFunc = func(t iterator, m, n interface{}) interface{} {
 	return numericExpr(t, m, n, func(a, b float64) float64 {
-		return float64(int(a) % int(b))
+		// XPath 1.0 REC §3.5: truncating IEEE remainder; mod by zero is NaN.
+		return math.Mod(a, b)
 	})
 }

--- a/xpath_function_test.go
+++ b/xpath_function_test.go
@@ -257,9 +257,36 @@ func Test_func_reverse(t *testing.T) {
 }
 
 func Test_func_round(t *testing.T) {
-	test_xpath_eval(t, employee_example, `round(2.5)`, 3) // int
-	test_xpath_eval(t, employee_example, `round(2.5)`, 3)
-	test_xpath_eval(t, employee_example, `round(2.4999)`, 2)
+	// round() returns a number (float64), consistent with ceiling()/floor().
+	test_xpath_eval(t, empty_example, `round(2.5)`, float64(3))
+	test_xpath_eval(t, empty_example, `round(2.4999)`, float64(2))
+	test_xpath_eval(t, empty_example, `round(0.5)`, float64(1))
+	test_xpath_eval(t, empty_example, `round(3.5)`, float64(4))
+	// REC §4.4: halves round toward +Infinity, not away from zero.
+	test_xpath_eval(t, empty_example, `round(-0.5)`, float64(0))
+	test_xpath_eval(t, empty_example, `round(-1.5)`, float64(-1))
+	test_xpath_eval(t, empty_example, `round(-2.5)`, float64(-2))
+	test_xpath_eval(t, empty_example, `round(-0.6)`, float64(-1))
+	test_xpath_eval(t, empty_example, `round(-0.4)`, float64(0))
+	// ±Infinity pass through instead of overflowing an int conversion.
+	test_xpath_eval(t, empty_example, `round(1 div 0)`, math.Inf(1))
+	test_xpath_eval(t, empty_example, `round(-1 div 0)`, math.Inf(-1))
+	assertTrue(t, math.IsNaN(MustCompile(`round(0 div 0)`).Evaluate(createNavigator(empty_example)).(float64)))
+	// A number result composes in further arithmetic (was NaN when round returned int).
+	test_xpath_eval(t, empty_example, `round(2.5) + 0.5`, float64(3.5))
+}
+
+func Test_func_mod(t *testing.T) {
+	// REC §3.5: truncating remainder; sign follows the dividend.
+	test_xpath_eval(t, empty_example, `5 mod 3`, float64(2))
+	test_xpath_eval(t, empty_example, `5 mod -3`, float64(2))
+	test_xpath_eval(t, empty_example, `-5 mod 3`, float64(-2))
+	test_xpath_eval(t, empty_example, `6 mod 3`, float64(0))
+	// operands keep their fractional part (were truncated to int before).
+	test_xpath_eval(t, empty_example, `5.5 mod 2`, float64(1.5))
+	test_xpath_eval(t, empty_example, `7.5 mod 3`, float64(1.5))
+	// mod by zero is NaN, not a panic.
+	assertTrue(t, math.IsNaN(MustCompile(`5 mod 0`).Evaluate(createNavigator(empty_example)).(float64)))
 }
 
 func Test_func_namespace_uri(t *testing.T) {


### PR DESCRIPTION
round() and the mod operator both diverge from XPath 1.0 (and from libxml2/lxml).

## round() — REC §4.4

`int(math.Round(f))` rounds halves away from zero and drops non-finite values:

- `round(-0.5)` → -1 (want 0), `round(-1.5)` → -2 (want -1), `round(-2.5)` → -3 (want -2); §4.4 rounds halves toward +Infinity.
- `round(1 div 0)` → 9223372036854775807, `round(-1 div 0)` → the int64 minimum, `round(0 div 0)` → 0; want Infinity / -Infinity / NaN.
- The int result isn't an XPath number, so `round(2.5) + 0.5` evaluates to NaN instead of 3.5 (asNumber only understands float64).

round() now returns float64 like ceiling()/floor(): NaN/±Infinity pass through, and finite values use `floor(f)` with a half-up carry. It no longer depends on the go1.10-only `math.Round`, so it moves next to roundFunc. (§4.4 notes that `floor(f + 0.5)` is wrong for the signed-zero cases, e.g. `round(-0.4)` is -0.)

## mod — REC §3.5

`float64(int(a) % int(b))` truncates the operands and panics on a zero divisor: `5.5 mod 2` → 1 (want 1.5) and `5 mod 0` panics with "integer divide by zero" (want NaN). `math.Mod` is the truncating IEEE remainder the spec calls for — the sign follows the dividend, and a zero divisor yields NaN.

All results checked against lxml/libxml2. The existing round tests are updated to the number result, and table tests are added for both classes covering the half-to-+Infinity, non-finite, and zero-divisor edges.

`go test ./...`, `go test -race ./...`, `go vet ./...`, `git diff --check`.
