### PR TITLE
Reject undeclared variables nested in an expression

### DIFF
--- a/build.go
+++ b/build.go
@@ -692,6 +692,19 @@ func (b *builder) processNode(root node, flags flag, props *builderProp) (q quer
 		}
 		q = &groupQuery{Input: q}
 		b.firstInput = q
+	case nodeVariable:
+		// Variables have no binding in a compiled expression, so they cannot
+		// resolve to a query. A bare "$x" already surfaces as an undeclared
+		// variable error because the nil result reaches the caller, but a
+		// variable nested in a larger expression (e.g. "$x/@attr") would be
+		// swallowed here and left as a nil sub-query that panics at select
+		// time. Report it as undeclared instead.
+		n := root.(*variableNode)
+		name := n.Name
+		if n.Prefix != "" {
+			name = n.Prefix + ":" + name
+		}
+		err = fmt.Errorf("undeclared variable in XPath expression: $%s", name)
 	}
 	b.parseDepth--
 	return

--- a/xpath_test.go
+++ b/xpath_test.go
@@ -181,6 +181,18 @@ func TestInvalidXPath(t *testing.T) {
 	assertErr(t, err)
 }
 
+// A variable reference nested inside a larger expression used to compile
+// without error and then panic at select time, because the builder had no
+// case for variable nodes and left a nil sub-query behind. Compilation should
+// report it as undeclared, matching the bare "$x" case.
+func TestCompileUndeclaredVariable(t *testing.T) {
+	for _, expr := range []string{"$x", "$x/@attr", "$var + 1", "//a[$x]"} {
+		if _, err := Compile(expr); err == nil {
+			t.Errorf("Compile(%q) expected an error for the undeclared variable, got nil", expr)
+		}
+	}
+}
+
 func TestCompileWithNS(t *testing.T) {
 	_, err := CompileWithNS("/foo", nil)
 	assertNil(t, err)


### PR DESCRIPTION
`processNode` in build.go handles every parse node type except `nodeVariable`. When a variable reference appears on its own, for example `$x`, the switch falls through and returns a nil query, which the caller in `Compile` turns into the existing "undeclared variable in XPath expression" error. When the same reference is nested inside a larger expression, for example `$x/@attr` or `//a[$x]`, the surrounding step compiles fine and embeds that nil sub-query, so `Compile` returns without error and the expression panics later with a nil pointer dereference when `Select` clones the query.

This adds a `nodeVariable` case that returns the same undeclared variable error, so both the bare and the nested forms fail at compile time instead of one of them panicking at select time.

This is the root cause of antchfx/htmlquery#31, where `QueryAll(doc, "$test/@attr")` panics inside `attributeQuery.Clone` rather than returning a parse error.

Added `TestCompileUndeclaredVariable` covering `$x`, `$x/@attr`, `$var + 1`, and `//a[$x]`. The full suite and `go vet` pass.
