### PR TITLE
parse: '*' is not a name character (§3.7) — fix name*expr lexing (#126)

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -903,8 +903,12 @@ func (s *scanner) scanName() string {
 }
 
 func isName(r rune) bool {
+	// '*' is not a name character (XPath 1.0 §3.7): a NCName immediately followed by '*'
+	// (e.g. `price*0.01`) must be scanned as name · MultiplyOperator · number, not as a single
+	// name "price*0.01". The '*' of a namespace wildcard (`prefix:*`) is handled explicitly in the
+	// scanner (the ':' branch, `if s.curr == '*'`), so dropping it here does not affect that case.
 	return string(r) != ":" && string(r) != "/" &&
-		(unicode.Is(first, r) || unicode.Is(second, r) || string(r) == "*")
+		(unicode.Is(first, r) || unicode.Is(second, r))
 }
 
 func isDigit(r rune) bool {

--- a/xpath_test.go
+++ b/xpath_test.go
@@ -1015,3 +1015,23 @@ func TestMergeQueryStaleStateAcrossEvaluations(t *testing.T) {
 	assertFalse(t, expr.Evaluate(createNavigator(doc)).(bool))
 	assertFalse(t, expr.Evaluate(createNavigator(empty)).(bool))
 }
+
+func TestMultiplyOperatorAfterName(t *testing.T) {
+	// https://github.com/antchfx/xpath/issues/126 — '*' is not a name character (XPath 1.0 §3.7).
+	// A name immediately followed by '*' with no surrounding spaces (e.g. `price*0.01`) must be
+	// scanned as name · MultiplyOperator · number. Before the fix it lexed as a single name
+	// "price*0.01", which selected an empty node-set and evaluated to NaN.
+	doc := createNode("", RootNode)
+	price := doc.createChildNode("price", ElementNode)
+	price.createChildNode("3231000", TextNode)
+
+	test_xpath_eval(t, doc, `price*0.01`, float64(32310))   // no spaces — the fix
+	test_xpath_eval(t, doc, `price * 0.01`, float64(32310)) // with spaces — already worked
+
+	// Namespace/axis wildcards must keep compiling ('*' handled outside isName).
+	for _, expr := range []string{`//*`, `//foo:*`, `child::*`} {
+		if _, err := Compile(expr); err != nil {
+			t.Errorf("Compile(%q) failed: %v", expr, err)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #126 (you asked about the `*` character).

### The bug

`isName` treats `*` as a name character, so `scanName` keeps consuming past it. An expression
where a name is immediately followed by `*` with no surrounding spaces — e.g. `price*0.01` — is
lexed as a **single name** `"price*0.01"` instead of `name · MultiplyOperator · number`. That name
matches nothing, so the step yields an empty node-set and the whole expression evaluates to `NaN`.

```go
// today
Compile("price*0.01")   // "price*0.01" scanned as one itemName → NaN at eval time
Compile("price * 0.01") // works, because the spaces end scanName
```

Per XPath 1.0 §3.7 (lexical structure): when the previous token can end an expression (here an
`NCName`), a following `*` is the `MultiplyOperator`, not part of the name. Only in a name-test
position is `*` a wildcard — and that path never goes through `isName`.

### The fix

Drop `|| string(r) == "*"` from `isName`.

### Wildcards are unaffected

- `prefix:*` (namespace wildcard) is handled explicitly by the scanner in the `:` branch
  (`if s.curr == '*' { s.name = "*" }`), not via `isName`.
- `*`, `//*`, `child::*` reach the parser through the dedicated `*` token, also not via `isName`.

The added test asserts `//*`, `//foo:*` and `child::*` still compile.

### Why it matters

Found while migrating a real production XPath/XSLT corpus: **66 expressions** of the form
`NAME*expr` (no space) were silently evaluating to `NaN` — e.g. `format-number(price*0.01, '#.00')`
produced `NaN` instead of the amount. No error, just a wrong result, which is the worst failure
mode for a data pipeline.

### Scope

Only the `*` lexing. The comparison-operator fixes discussed in #126 (`'14' > 0`, `'abc' = 1`,
`'2' < '10'`, `//Moneda = 1`) are already on `master` (43837f1), so this PR stays focused.

### Test

`TestMultiplyOperatorAfterName` in `xpath_test.go`: `price*0.01` and `price * 0.01` both yield the
product; the three wildcard forms still compile. `go test ./...` is green.
